### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,34 @@ $ npm -i fwsp-umf-message
 ## Usage
 
 ```javascript
-const Utils = require('fwsp-umf-message');
-let instanceID = 'fa1ae8d5-86fc-44af-aad8-cd2740aef041';
+const UMFMessage = require('fwsp-umf-message');
 let msg = UMFMessage.createMessage({
-  to: `${instanceID}@test-service:[GET]/v1/somedata`,
+  to: `test-service:[GET]/v1/somedata`,
   from: 'client:/',
-  body: {}
+  body: {
+    somevalues: [1,2,3,4]
+  }
 });
+```
+
+You can also access message fields for getting and setting:
+
+```javascript
+console.log('msg.to', msg.to);
+msg.to = 'router:/';
+console.log('msg.to', msg.to);
+```
+
+To retrieve an entire message object using:
+
+```javascript
+console.log(msg.getMessage());
+```
+
+And you get get a JSON string using:
+
+```javascript
+console.log(msg.toJSON())
 ```
 
 ## Tests
@@ -26,144 +47,4 @@ Tests can be found in the `specs` folder.
 
 ```shell
 $ npm test
-```
-
-## API
-
-See: [API documentation](api.md)
-
-### createMessageID - Returns a UUID for use with messages
-
-```javascript
-/**
-  * @name createMessageID
-  * @summary Returns a UUID for use with messages
-  * @return {string} uuid - UUID
-  */
-  createMessageID()
-```
-
-### createShortMessageID - Returns a short form UUID for use with messages
-
-```javascript
-  /**
-  * @name createShortMessageID
-  * @summary Returns a short form UUID for use with messages
-  * @return {string} uuid - UUID
-  */
-  createShortMessageID()
-```
-
-### createMessage - Create a UMF style message
-
-```javascript
-  /**
-  * @name createMessage
-  * @summary Create a UMF style message.
-  * @description This is a helper function which helps format a UMF style message.
-  *              The caller is responsible for ensuring that required fields such as
-  *              "to", "from" and "body" are provided either before or after using
-  *              this function.
-  * @param {object} message - optional message overrides.
-  * @param {boolean} shortFormat - optional flag to use UMF short form syntax.
-  * @return {object} message - a UMF formatted message.
-  */
-  createMessage(message, shortFormat=false)
-```
-
-### createMessageShort - Create a short-format UMF message
-
-```javascript
-/**
-* @name createMessageShort
-* @summary createMessage with short fields
-* @param {object} message - optional message overrides.
-* @return {object} message - a UMF formatted short-form message.
-*/
-createMessageShort(message)
-```
-
-### toObject - get message as Object (no Proxy)
-
-```javascript
-/**
-* @name toObject
-* @param {object} message - message to be converted
-* @return {object} unproxied message object
-*/
-toObject(message)
-```
-
-### toJSON - serialize message to JSON string
-
-```javascript
-/**
-* @name toJSON
-* @param {object} message - message to be converted
-* @return {string} JSON version of message
-*/
-toJSON(message)
-```
-
-### toShort - convert a long message to a short one
-
-```javascript
-/**
-* @name toShort
-* @summary convert a long message to a short one
-* @param {object} message - message to be converted
-* @return {object} converted message
-*/
-toShort(message)
-```
-
-### toLong - convert a short message to a long one
-
-```javascript
-/**
-* @name toLong
-* @summary convert a short message to a long one
-* @param {object} message - message to be converted
-* @return {object} converted message
-*/
-toLong(message)
-```
-
-### validateMessage - Validates that a UMF message has required fields
-
-```javascript
-  /**
-  * @name validateMessage
-  * @summary Validates that a UMF message has required fields
-  * @param {object} message - UMF formatted message
-  * @return {boolean} response - returns true is valid otherwise false
-  */
-  validateMessage(message)
-```
-
-### getMessageBody - Return the body from a UMF message
-
-```javascript
-  /**
-  * @name getMessageBody
-  * @summary Return the body from a UMF message
-  * @param {object} message - UMF message
-  * @return {object} body - UMF message body
-  */
-  getMessageBody(message)
-```
-
-### parseRoute - parses message route strings
-
-```javascript
-  /**
-   * @name parseRoute
-   * @summary parses message route strings
-   * @private
-   * @param {string} toValue - string to be parsed
-   * @return {object} object - containing route parameters. If the
-   *                  object contains an error field then the route
-   *                  isn't valid.
-   */
-  parseRoute(toValue)
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-umf-message",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "umf-message: a tool for creating and working with UMF style messages",
   "author": "Carlos Justiniano",
   "analyze": false,

--- a/specs/tests.js
+++ b/specs/tests.js
@@ -130,38 +130,4 @@ describe('toJSON', () => {
     let parsed = Utils.safeJSONParse(json);
     expect(parsed).to.have.property('from');
   });
-
-});
-
-describe('get message body', () => {
-  let longMsg = UMFMessage.createMessage({
-    to: 'someservice:/',
-    from: 'tester',
-    body: {
-      val: 'some value'
-    }
-  }),
-  shortMsg = UMFMessage.createMessageShort({
-    to: 'someservice:/',
-    frm: 'tester',
-    bdy: {
-      val: 'some value'
-    }
-  });
-  it('should get message body from long-form message', () => {
-    let body = UMFMessage.getMessageBody(longMsg);
-    expect(body).to.have.property('val');
-  });
-  it('should get message body from converted short-form message', () => {
-    let body = UMFMessage.getMessageBody(UMFMessage.toShort(longMsg));
-    expect(body).to.have.property('val');
-  });
-  it('should get message body from new short-form message', () => {
-    let body = UMFMessage.getMessageBody(shortMsg);
-    expect(body).to.have.property('val');
-  });
-  it('should get message body from converted long-form message', () => {
-    let body = UMFMessage.getMessageBody(UMFMessage.toLong(shortMsg));
-    expect(body).to.have.property('val');
-  });
 });

--- a/specs/tests.js
+++ b/specs/tests.js
@@ -13,33 +13,30 @@ describe('createMessage', () => {
 
   it('should have standard properties', () => {
     let msg = UMFMessage.createMessage({});
-    expect(msg).to.have.property('mid');
-    expect(msg).to.have.property('timestamp');
-    expect(msg).to.have.property('version');
+    expect(msg.mid).to.not.be.undefined;
+    expect(msg.timestamp).to.not.be.undefined;
+    expect(msg.version).to.not.be.undefined;
   });
 
   it('should have standard properties for short messages', () => {
-    let msg = UMFMessage.createMessageShort({});
-    expect(msg).to.have.property('mid');
-    expect(msg).to.have.property('ts');
-    expect(msg).to.have.property('ver');
+    let msg = UMFMessage.createMessage({}).toShort();
+    expect(msg.mid).to.not.be.undefined;
+    expect(msg.ts).to.not.be.undefined;
+    expect(msg.ver).to.not.be.undefined;
   });
 });
 
 describe('message conversion to and from short form', () => {
   it('should convert a short form message to a long form message', () => {
-    let msg = UMFMessage.createMessageShort({
+    let msg = UMFMessage.createMessage({
       to: 'someservice:/',
       frm: 'tester',
       bdy: {
         val: 'some value'
       }
     });
-    let longFormMessage = UMFMessage.toLong(msg);
-    expect(longFormMessage).to.have.property('from');
-    expect(longFormMessage).to.have.property('body');
-    expect(longFormMessage).not.to.have.property('frm');
-    expect(longFormMessage).not.to.have.property('bdy');
+    expect(msg.from).to.not.be.undefined;
+    expect(msg.body).to.not.be.undefined;
   });
   it('should convert a long form message to a short form message', () => {
     let msg = UMFMessage.createMessage({
@@ -49,7 +46,7 @@ describe('message conversion to and from short form', () => {
         val: 'some value'
       }
     });
-    let shortFormMessage = UMFMessage.toShort(msg);
+    let shortFormMessage = msg.toShort();
     expect(shortFormMessage).to.have.property('frm');
     expect(shortFormMessage).to.have.property('bdy');
     expect(shortFormMessage).not.to.have.property('from');
@@ -60,19 +57,19 @@ describe('message conversion to and from short form', () => {
 describe('validateMessage', () => {
   it('should return false if missing from field', () => {
     let msg = UMFMessage.createMessage({});
-    let ret = UMFMessage.validateMessage(msg);
+    let ret = msg.validateMessage();
     expect(ret).to.be.false;
     expect(msg['from']).to.be.undefined;
   });
   it('should return false if missing to field', () => {
     let msg = UMFMessage.createMessage({});
-    let ret = UMFMessage.validateMessage(msg);
+    let ret = msg.validateMessage();
     expect(ret).to.be.false;
     expect(msg['to']).to.be.undefined;
   });
   it('should return false if missing body field', () => {
     let msg = UMFMessage.createMessage({});
-    let ret = UMFMessage.validateMessage(msg);
+    let ret = msg.validateMessage();
     expect(ret).to.be.false;
     expect(msg['body']).to.be.undefined;
   });
@@ -83,7 +80,7 @@ describe('validateMessage', () => {
       from: 'client:/',
       body: {}
     });
-    let ret = UMFMessage.validateMessage(msg);
+    let ret = msg.validateMessage();
     expect(ret).to.be.true;
   });
 });
@@ -119,38 +116,9 @@ describe('parseRoute', () => {
   });
 });
 
-describe('proxied object', () => {
-  it('should return values for long-form keys on short-form message ', () => {
-    let msg = UMFMessage.createMessageShort({
-      to: 'someservice:/',
-      frm: 'tester',
-      bdy: {
-        val: 'some value'
-      }
-    });
-    expect(msg.frm).to.equal(msg.from);
-    expect(msg.bdy).to.equal(msg.body);
-    expect(msg.ts).to.equal(msg.timestamp);
-    expect(msg.ver).to.equal(msg.version);
-  });
-
-  it('should return values for short-form keys on long-form message', () => {
-    let msg = UMFMessage.createMessage({
-      to: 'someservice:/',
-      from: 'tester',
-      body: {
-        val: 'some value'
-      }
-    });
-    expect(msg.from).to.equal(msg.frm);
-    expect(msg.body).to.equal(msg.bdy);
-    expect(msg.timestamp).to.equal(msg.ts);
-    expect(msg.version).to.equal(msg.ver);
-  });
-});
 
 describe('toJSON', () => {
-  it('should return long-form keys in JSON for a long-form message', () => {
+  it('should return valid JSON for message', () => {
     let msg = UMFMessage.createMessage({
       to: 'someservice:/',
       from: 'tester',
@@ -158,21 +126,9 @@ describe('toJSON', () => {
         val: 'some value'
       }
     });
-    let json = UMFMessage.toJSON(msg);
+    let json = msg.toJSON(msg);
     let parsed = Utils.safeJSONParse(json);
     expect(parsed).to.have.property('from');
-  });
-  it('should return short-form keys in JSON for a short-form message', () => {
-    let msg = UMFMessage.createMessageShort({
-      to: 'someservice:/',
-      frm: 'tester',
-      bdy: {
-        val: 'some value'
-      }
-    });
-    let json = UMFMessage.toJSON(msg);
-    let parsed = Utils.safeJSONParse(json);
-    expect(parsed).to.have.property('frm');
   });
 
 });


### PR DESCRIPTION
A complete overhaul.

Now importing fwsp-umf-message returns an module which exports two functions:
`createMessage` and `parseRoute`.  When you create a message it behaves like an object using the ES6 proxy feature.
