### PR TITLE
refactoring and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,10 @@ msg.to = 'router:/';
 console.log('msg.to', msg.to);
 ```
 
-To retrieve an entire message object using:
+To retrieve an entire message object use:
 
 ```javascript
-console.log(msg.getMessage());
-```
-
-And you get get a JSON string using:
-
-```javascript
-console.log(msg.toJSON())
+console.log(msg.toJSON());
 ```
 
 ## Tests

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const moment = require('moment');
 const uuid = require('uuid');
-const Utils = require('fwsp-jsutils');
 
 const UMF_VERSION = 'UMF/1.4.3';
 const UMF_INVALID_MESSAGE = 'UMF message requires "to", "from" and "body" fields';
@@ -14,21 +12,12 @@ class UMFMessage {
   }
 
   /**
-  * @name getMessage
-  * @summary Returns a plain-old JavaScript object
-  * @return {object} obj - a Plain old JavaScript Object.
-  */
-  getMessage() {
-    return Object.assign({}, this.message);
-  }
-
-  /**
   * @name getTimeStamp
   * @summary retrieve an ISO 8601 timestamp
   * @return {string} timestamp - ISO 8601 timestamp
   */
   getTimeStamp() {
-    return moment().toISOString();
+    return new Date().toISOString();
   }
 
   /**
@@ -43,20 +32,20 @@ class UMFMessage {
   /**
   * @name createShortMessageID
   * @summary Returns a short form UUID for use with messages
-  * @return {string} uuid - UUID
+   @see https://en.wikipedia.org/wiki/Base36
+  * @return {string} short identifer
   */
   createShortMessageID() {
-    return Utils.shortID();
+    return (Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString(36);
   }
 
 
   /**
   * @name toJSON
-  * @param {object} message - message to be converted
-  * @return {string} JSON version of message
+  * @return {object} A JSON stringifiable version of message
   */
-  toJSON(message) {
-    return Utils.safeJSONStringify(this.message);
+  toJSON() {
+    return this.message;
   }
 
   /**
@@ -97,11 +86,11 @@ class UMFMessage {
   }
 
   /**
-  * @name validateMessage
+  * @name validate
   * @summary Validates that a UMF message has required fields
   * @return {boolean} response - returns true is valid otherwise false
   */
-  validateMessage() {
+  validate() {
     if (!this.message.from || !this.message.to || !this.message.body) {
       return false;
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fwsp-umf-message",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "umf-message: a tool for creating and working with UMF style messages",
   "author": "Carlos Justiniano",
   "analyze": false,
@@ -12,8 +12,6 @@
     "test": "mocha specs --reporter spec"
   },
   "dependencies": {
-    "fwsp-jsutils": "1.0.8",
-    "moment": "2.14.1",
     "uuid": "2.0.2"
   },
   "devDependencies": {

--- a/specs/tests.js
+++ b/specs/tests.js
@@ -54,22 +54,22 @@ describe('message conversion to and from short form', () => {
   });
 });
 
-describe('validateMessage', () => {
+describe('validate', () => {
   it('should return false if missing from field', () => {
     let msg = UMFMessage.createMessage({});
-    let ret = msg.validateMessage();
+    let ret = msg.validate();
     expect(ret).to.be.false;
     expect(msg['from']).to.be.undefined;
   });
   it('should return false if missing to field', () => {
     let msg = UMFMessage.createMessage({});
-    let ret = msg.validateMessage();
+    let ret = msg.validate();
     expect(ret).to.be.false;
     expect(msg['to']).to.be.undefined;
   });
   it('should return false if missing body field', () => {
     let msg = UMFMessage.createMessage({});
-    let ret = msg.validateMessage();
+    let ret = msg.validate();
     expect(ret).to.be.false;
     expect(msg['body']).to.be.undefined;
   });
@@ -80,7 +80,7 @@ describe('validateMessage', () => {
       from: 'client:/',
       body: {}
     });
-    let ret = msg.validateMessage();
+    let ret = msg.validate();
     expect(ret).to.be.true;
   });
 });
@@ -126,8 +126,7 @@ describe('toJSON', () => {
         val: 'some value'
       }
     });
-    let json = msg.toJSON(msg);
-    let parsed = Utils.safeJSONParse(json);
-    expect(parsed).to.have.property('from');
+    let json = msg.toJSON();
+    expect(json).to.have.property('from');
   });
 });


### PR DESCRIPTION
- Removed moment and fwsp-jsutils since they're not really needed.
- Removed getMessage() because toJSON should be used instead.
- Change toJSON to return an object which can be serialized by JSON.stringify. This is the standard behavior.
- Changed validateMessage() to just validate() for brevity.
- Updated tests.
